### PR TITLE
Fix line rule validation issue.

### DIFF
--- a/src/DocSharp.Docx/Helpers/OpenXmlHelpers.cs
+++ b/src/DocSharp.Docx/Helpers/OpenXmlHelpers.cs
@@ -487,6 +487,11 @@ public static class OpenXmlHelpers
         // Check default paragraph style for the current document
         MergeAttributes(res, stylesPart.GetDefaultParagraphStyle()?.SpacingBetweenLines, attributes);
 
+        var resAttributes = res.GetAttributes();
+        var lineRuleAttribute = resAttributes.FirstOrDefault(x => x.LocalName.Equals("lineRule", StringComparison.OrdinalIgnoreCase));
+        if(string.IsNullOrWhiteSpace(lineRuleAttribute.Value))
+            res.RemoveAttribute(lineRuleAttribute.LocalName, lineRuleAttribute.NamespaceUri);
+
         return res;
     }
 


### PR DESCRIPTION
If the attribute value provided for the lineRule is empty, don't use the attribute. Maybe we should replace the value with the default?