### PR TITLE
Fix: Escape parentheses in markdown link URLs from DOCX conversion

### DIFF
--- a/src/DocSharp.Common/Writers/MarkdownStringWriter.cs
+++ b/src/DocSharp.Common/Writers/MarkdownStringWriter.cs
@@ -114,6 +114,8 @@ public sealed class MarkdownStringWriter : BaseStringWriter
         else
             // Microsoft Word usually escapes spaces in the relationship, but we ensure it here.
             target = target.Replace(" ", "%20");
+            // Escape parentheses to avoid breaking markdown link syntax: [text](url)
+            target = target.Replace("(", "%28").Replace(")", "%29");
 
         Write($"[{displayText}]({target}");
         if (!string.IsNullOrWhiteSpace(tooltip))


### PR DESCRIPTION
### Description

When converting DOCX files to Markdown, hyperlinks containing parentheses in their URLs produce broken markdown. For example, a link to `https://en.wikipedia.org/wiki/Mole_(unit)` would generate:

```
[text](https://en.wikipedia.org/wiki/Mole_(unit))
```

The unescaped `)` prematurely terminates the markdown link syntax `[text](url)`, resulting in malformed output.

### Fix

Added percent-encoding for parentheses in the target URL within `MarkdownStringWriter.WriteHyperlink` (`src/DocSharp.Common/Writers/MarkdownStringWriter.cs:117`):

- `(` → `%28`
- `)` → `%29`

#32 is fixed.